### PR TITLE
fix: avoid opening too many tabs

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,11 @@
-import { EditorPosition, TFile, Editor, MarkdownView, Plugin } from 'obsidian';
+import {
+	EditorPosition,
+	TFile,
+	MarkdownView,
+	Plugin,
+	WorkspaceLeaf,
+	App,
+} from "obsidian";
 
 interface History {
 	file: TFile;
@@ -6,9 +13,6 @@ interface History {
 	ch: number;
 }
 
-// function historyToString(history: History) {
-// 	return `${history.file.path}@${history.line}`
-// }
 function logHistory(backward: History[], cur: History, forward: History[]) {
 	// console.log(backward.map(historyToString), historyToString(cur), forward.map(historyToString))
 }
@@ -16,11 +20,12 @@ function logHistory(backward: History[], cur: History, forward: History[]) {
 export default class NavigateCursorHistory extends Plugin {
 	backward: History[] = [];
 	forward: History[] = [];
-	cur: History;
+	cur: History | null = null;
 
 	async onload() {
 		this.registerEvent(
-			this.app.workspace.on('file-open', (file) => {
+			this.app.workspace.on("file-open", (file) => {
+				if (file === null) return;
 				if (!this.cur) {
 					this.cur = { file, line: 0, ch: 0 };
 				}
@@ -32,66 +37,119 @@ export default class NavigateCursorHistory extends Plugin {
 
 		// This adds an editor command that can perform some operation on the current editor instance
 		this.addCommand({
-			id: 'cursor-position-backward',
-			name: 'Go back',
-			editorCallback: async (editor: Editor, view: MarkdownView) => {
+			id: "cursor-position-backward",
+			name: "Go back",
+			callback: async () => {
 				if (this.backward.length < 1) return;
-				const cur = this.cur
-				const prev = this.backward.pop()
-				this.forward.push(cur)
+				const cur = this.cur;
+				if (!cur) return;
+				const prev = this.backward.pop() as History;
+				this.forward.push(cur);
+				this.cur = prev;
 				if (cur.file !== prev.file) {
-					await this.app.workspace.getMostRecentLeaf().openFile(prev.file)
+					const leaf = findLeafForFile(this.app, prev.file);
+					if (leaf) {
+						this.app.workspace.setActiveLeaf(leaf, true, true);
+					} else {
+						await this.app.workspace
+							.getMostRecentLeaf()
+							.openFile(prev.file);
+					}
 				}
-				this.cur = prev
-				const pos: EditorPosition = { line: prev.line, ch: prev.ch }
-				editor.setSelection(pos);
-				editor.scrollIntoView({ from: pos, to: pos }, true);
-				logHistory(this.backward, this.cur, this.forward)
-			}
+				const pos: EditorPosition = { line: prev.line, ch: prev.ch };
+				const editor =
+					this.app.workspace.getActiveViewOfType(
+						MarkdownView,
+					)?.editor;
+				if (editor) {
+					editor.setSelection(pos);
+					editor.scrollIntoView({ from: pos, to: pos }, true);
+				}
+				logHistory(this.backward, this.cur, this.forward);
+			},
 		});
 		this.addCommand({
-			id: 'cursor-position-forward',
-			name: 'Go forward',
-			editorCallback: async (editor: Editor, view: MarkdownView) => {
+			id: "cursor-position-forward",
+			name: "Go forward",
+			callback: async () => {
 				if (this.forward.length < 1) return;
-				const cur = this.cur
-				const prev = this.forward.pop()
-				this.backward.push(this.cur)
-				this.cur = prev
+				const cur = this.cur;
+				if (!cur) return;
+				const prev = this.forward.pop() as History;
+				this.backward.push(cur);
+				this.cur = prev;
 				if (cur.file !== prev.file) {
-					await this.app.workspace.getMostRecentLeaf().openFile(prev.file)
+					const leaf = findLeafForFile(this.app, prev.file);
+					if (leaf) {
+						this.app.workspace.setActiveLeaf(leaf, true, true);
+					} else {
+						await this.app.workspace
+							.getMostRecentLeaf()
+							.openFile(prev.file);
+					}
 				}
-				const pos: EditorPosition = { line: prev.line, ch: prev.ch }
-				editor.setSelection(pos);
-				editor.scrollIntoView({ from: pos, to: pos }, true);
-				logHistory(this.backward, this.cur, this.forward)
-			}
+				const pos: EditorPosition = { line: prev.line, ch: prev.ch };
+				const editor =
+					this.app.workspace.getActiveViewOfType(
+						MarkdownView,
+					)?.editor;
+				if (editor) {
+					editor.setSelection(pos);
+					editor.scrollIntoView({ from: pos, to: pos }, true);
+				}
+				logHistory(this.backward, this.cur, this.forward);
+			},
 		});
 
-		this.registerInterval(window.setInterval(() => {
-			if (!this.cur) return;
-			const editor = this.app.workspace.getActiveViewOfType(MarkdownView)?.editor
-			if (editor) {
-				const cursor = editor.getCursor("head");
-				this.saveHistory(this.cur.file, cursor);
-			}
-		}, 1 * 1000));
+		this.registerInterval(
+			window.setInterval(() => {
+				if (!this.cur) return;
+				const editor =
+					this.app.workspace.getActiveViewOfType(
+						MarkdownView,
+					)?.editor;
+				if (editor) {
+					const cursor = editor.getCursor("head");
+					this.saveHistory(this.cur.file, cursor);
+				}
+			}, 1 * 1000),
+		);
 	}
 
-	onunload() {
-
-	}
+	onunload() {}
 
 	saveHistory(file: TFile, cursor: EditorPosition) {
-		if (file === this.cur.file && cursor.line === this.cur.line && cursor.ch === this.cur.ch) return;
-		if (file === this.cur.file && cursor.line === this.cur.line && cursor.ch !== this.cur.ch) {
-			this.cur.ch = cursor.ch
-			return
+		if (!this.cur) return;
+		if (
+			file === this.cur.file &&
+			cursor.line === this.cur.line &&
+			cursor.ch === this.cur.ch
+		)
+			return;
+		if (
+			file === this.cur.file &&
+			cursor.line === this.cur.line &&
+			cursor.ch !== this.cur.ch
+		) {
+			this.cur.ch = cursor.ch;
+			return;
 		}
-		this.backward.push(this.cur)
-		this.cur = { file, line: cursor.line, ch: cursor.ch }
-		this.backward = this.backward.slice(-50)
-		this.forward = []
-		logHistory(this.backward, this.cur, this.forward)
+		this.backward.push(this.cur);
+		this.cur = { file, line: cursor.line, ch: cursor.ch };
+		this.backward = this.backward.slice(-50);
+		this.forward = [];
+		logHistory(this.backward, this.cur, this.forward);
 	}
+}
+
+function findLeafForFile(app: App, file: TFile): WorkspaceLeaf | null {
+	let found: WorkspaceLeaf | null = null;
+	app.workspace.iterateAllLeaves((leaf) => {
+		if (found) return;
+		const view = leaf.view;
+		if (view instanceof MarkdownView && view.file === file) {
+			found = leaf;
+		}
+	});
+	return found;
 }


### PR DESCRIPTION
## what this PR did

1. fix: typescript lint errors
2. fix: avoid reopening tabs that is already opened in the workspace when go back or forth
3. fix: use `callback` instead of `editorCallback` to enable the feature even when cursor is in the title section.

## demo

<img width="320" height="180" alt="output_5mb" src="https://github.com/user-attachments/assets/c3bf906a-8987-4b7e-9daa-557201c54795" />
